### PR TITLE
adopt mission protocol 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,137 +1,55 @@
-# Code of Conduct
+## Mission
 
-This code of conduct outlines our expectations for participants within the
-**Coinbase** open source community, as well as steps to reporting unacceptable
-behavior. We are committed to providing a welcoming and inspiring community for
-all and expect our code of conduct to be honored. Anyone who violates this code
-of conduct may be banned from the community.
+To create an open financial system for the world.
 
-Our open source community strives to:
+## Objective
 
-- **Be friendly and patient.**
-- **Be welcoming**: We strive to be a community that welcomes and supports
-  people of all backgrounds and identities. This includes, but is not limited to
-  members of any race, ethnicity, culture, national origin, colour, immigration
-  status, social and economic class, educational level, sex, sexual orientation,
-  gender identity and expression, age, size, family status, political belief,
-  religion, and mental and physical ability.
-- **Be considerate**: Your work will be used by other people, and you in turn
-  will depend on the work of others. Any decision you take will affect users and
-  colleagues, and you should take those consequences into account when making
-  decisions. Remember that we’re a world-wide community, so you might not be
-  communicating in someone else’s primary language.
-- **Be respectful**: Not all of us will agree all the time, but disagreement is
-  no excuse for poor behavior and poor manners. We might all experience some
-  frustration now and then, but we cannot allow that frustration to turn into a
-  personal attack. It’s important to remember that a community where people feel
-  uncomfortable or threatened is not a productive one.
-- **Be careful in the words that we choose**: we are a community of
-  professionals, and we conduct ourselves professionally. Be kind to others. Do
-  not insult or put down other participants. Harassment and other exclusionary
-  behavior aren’t acceptable.
-- **Try to understand why we disagree**: Disagreements, both social and
-  technical, happen all the time. It is important that we resolve disagreements
-  and differing views constructively. Remember that we’re different. The
-  strength of our community comes from its diversity, people from a wide range
-  of backgrounds. Different people have different perspectives on issues. Being
-  unable to understand why someone holds a viewpoint doesn’t mean that they’re
-  wrong. Don’t forget that it is human to err and blaming each other doesn’t get
-  us anywhere. Instead, focus on helping to resolve issues and learning from
-  mistakes.
+Our objective is to focus on the mission we set out to accomplish, which we believe will produce an important social good in the world. Our standards are directed towards achieving this mission. We will conduct ourselves with professional integrity and set aside divisive discourse that doesn’t help us achieve our mission.
 
-## Definitions
+## Standards
 
-Harassment includes, but is not limited to:
+**Leadership principle:** Project leaders are responsible and authorized to make judgments and take appropriate actions to define the mission and keep the project in line with this mission.
 
-- Offensive comments related to gender, gender identity and expression, sexual
-  orientation, disability, mental illness, neuro(a)typicality, physical
-  appearance, body size, race, age, regional discrimination, political or
-  religious affiliation
-- Unwelcome comments regarding a person’s lifestyle choices and practices,
-  including those related to food, health, parenting, drugs, and employment
-- Deliberate misgendering. This includes deadnaming or persistently using a
-  pronoun that does not correctly reflect a person’s gender identity. You must
-  address people by the name they give you when not addressing them by their
-  username or handle
-- Physical contact and simulated physical contact (eg, textual descriptions like
-  “*hug*” or “*backrub*”) without consent or after a request to stop
-- Threats of violence, both physical and psychological
-- Incitement of violence towards any individual, including encouraging a person
-  to commit suicide or to engage in self-harm
-- Deliberate intimidation
-- Stalking or following
-- Harassing photography or recording, including logging online activity for
-  harassment purposes
-- Sustained disruption of discussion
-- Unwelcome sexual attention, including gratuitous or off-topic sexual images or
-  behaviour
-- Pattern of inappropriate social contact, such as requesting/assuming
-  inappropriate levels of intimacy with others
-- Continued one-on-one communication after requests to cease
-- Deliberate “outing” of any aspect of a person’s identity without their consent
-  except as necessary to protect others from intentional abuse
-- Publication of non-harassing private communication
+**Mission focus:** We will focus our efforts on accomplishing the project’s mission, so that it is fulfilled to its highest potential.
 
-Our open source community prioritizes marginalized people’s safety over
-privileged people’s comfort. We will not act on complaints regarding:
+**Creative conflict:** We acknowledge that discussions and disagreements are a natural part of problem-solving and should happen in a constructive way.
 
-- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
-- Reasonable communication of boundaries, such as “leave me alone,” “go away,”
-  or “I’m not discussing this with you”
-- Refusal to explain or debate social justice concepts
-- Communicating in a ‘tone’ you don’t find congenial
-- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or
-  assumptions
+**The whole is greater than the parts:** We are a project with diverse opinions and fields of engagement, but we are here to focus on what unites us, instead of what divides us.
 
-### Diversity Statement
+**Principle of charity:** We assume positive intentions of members, contributors, and policies.
 
-We encourage everyone to participate and are committed to building a community
-for all. Although we will fail at times, we seek to treat everyone both as
-fairly and equally as possible. Whenever a participant has made a mistake, we
-expect them to take responsibility for it. If someone has been harmed or
-offended, it is our responsibility to listen carefully and respectfully, and do
-our best to right the wrong.
+## Prohibited Behavior
 
-Although this list cannot be exhaustive, we explicitly honor diversity in age,
-gender, gender identity or expression, culture, ethnicity, language, national
-origin, political beliefs, profession, race, religion, sexual orientation,
-socioeconomic status, and technical ability. We will not tolerate discrimination
-based on any of the protected characteristics above, including participants with
-disabilities.
+* Harassment, i.e., excessive, hostile, or bad-faith communication directed at another member or contributor
+* Attacks based on personal characteristics
+* Threats of violence
+* Threatening to publish or publishing people’s personal information without their consent
+* Repeatedly attempting to involve the project in issues outside of its mission
+* Posting illegal content
+* Abuse of the system for reporting code of conduct violations
+* Promoting any behavior listed above
 
-### Reporting Issues
+## Responsibilities
 
-If you experience or witness unacceptable behavior—or have any other
-concerns—please report it by contacting us via
-**[opensource@coinbase.com](mailto:opensource@coinbase.com)**. All reports will be handled with
-discretion. In your report please include:
+In line with the leadership principle, project leaders have the responsibility to clarify and interpret the mission, as well as the intentions and standards in this code of conduct, in order to maintain mission focus. When individuals engage in prohibited behavior, project leaders are expected to take expedient, fair, and appropriate action to address the violation(s). The standards and prohibitions in this document also apply to project leaders.
 
-- Your contact information.
-- Names (real, nicknames, or pseudonyms) of any individuals involved. If there
-  are additional witnesses, please include them as well. Your account of what
-  occurred, and if you believe the incident is ongoing. If there is a publicly
-  available record (e.g. a mailing list archive or a public IRC logger), please
-  include a link.
-- Any additional information that may be helpful.
+## Conflict Resolution
 
-After filing a report, a representative will contact you personally, review the
-incident, follow up with any additional questions, and make a decision as to how
-to respond. If the person who is harassing you is part of the response team,
-they will recuse themselves from handling your incident. If the complaint
-originates from a member of the response team, it will be handled by a different
-member of the response team. We will respect confidentiality requests for the
-purpose of protecting victims of abuse.
+### Reporting
 
-### Attribution & Acknowledgements
+We highly encourage contributors to resolve conflicts by directly reaching out to the other party or parties involved in the dispute. When this is insufficient, members can report the issue to project leaders via email at opensource@coinbase.com within 31 days of the inciting event and request a formal resolution.
 
-We all stand on the shoulders of giants across many open source communities.
-We’d like to thank the communities and projects that established code of
-conducts and diversity statements as our inspiration:
+Project leaders will make reasonable efforts to adjudicate incidents shortly after they are brought to their attention.
 
-- [Django](https://www.djangoproject.com/conduct/reporting/)
-- [Python](https://www.python.org/community/diversity/)
-- [Ubuntu](http://www.ubuntu.com/about/about-ubuntu/conduct)
-- [Contributor Covenant](http://contributor-covenant.org/)
-- [Geek Feminism](http://geekfeminism.org/about/code-of-conduct/)
-- [Citizen Code of Conduct](http://citizencodeofconduct.org/)
-- [TODO Group](http://todogroup.org/opencodeofconduct/)
+### Enforcement
+
+Project leaders shall take all reasonable actions to ensure the successful execution of the mission statement and the maximum effectiveness of the project.
+
+All material in official project spaces is subject to the code of conduct, and as such, can be deleted, modified, or rejected by project leaders if it is found to be in violation of the code of conduct. In repeated or severe cases, project leaders may exclude individuals from further contribution to the project on a temporary or permanent basis.
+
+## Scope
+This code of conduct applies to official project spaces, which include but are not limited to: social media, conferences, code repositories, and discussion boards. This code of conduct also applies to members and contributors who represent the project in non-project spaces, such as when contributors give a talk on behalf of the project at a conference. In official spaces, members and contributors should operate with decorum that reflects positively on the project, its objectives, and its community.
+
+## Licensing
+
+The Mission Protocol Code of Conduct was created under the CC BY 4.0 License in 2020.


### PR DESCRIPTION
The current version of the Coinbase code of conduct appears to be a three year old version of the [Open Code of Conduct](https://github.com/todogroup/opencodeofconduct), which is an archived project that will no longer be updated, and is no longer available online.  The language in this document isn't congruent with most of the modern codes of conduct in use.  [Mission Protocol](https://missionprotocol.org/) is a recent code of conduct that was directly inspired by Brian's blog post on mission focus, and was mentioned by him in [this tweet](https://twitter.com/brian_armstrong/status/1318357948867866624).  I think the values in here are well aligned with Coinbase so I wanted to open this to start the conversation about adopting Mission Protocol in Coinbase's open source projects.